### PR TITLE
fix compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "moduleResolution": "node",
     "module": "es2015",
     "target": "es5",
     "removeComments": true,


### PR DESCRIPTION
I get compiler errors without this fix.

Since you have specified modules: "es2015" on your tsconfig.json. TypeScript Compiler will use Classic module resolution, which unfortunately, does not resolve non-relative imports in node_modules. check https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies